### PR TITLE
Diagnose and harden empty careers feed on jobs page

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -172,23 +172,33 @@ export async function collegeNewsQuery() {
   }
 }
 
-export async function careersFeedQuery() {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 5000);
+// The advanced-search feed filtered to the Robotics Department (term ID 210308,
+// name "CoE Robotics"). Tried in order until one yields items: the department
+// exposed filter has matched by name and by taxonomy ID at different times, and
+// a mismatch produces a valid-but-empty channel rather than an error.
+const CAREERS_FEED_URLS = [
+  'https://careers.umich.edu/search/feed/advanced?career_interest=All&department=CoE%20Robotics&field_job_modes_of_work_target_id=All&job_id=&keyword=&position=All&regular_temporary=All&title=&work_location=All',
+  'https://careers.umich.edu/search/feed/advanced?career_interest=All&department=210308&field_job_modes_of_work_target_id=All&job_id=&keyword=&position=All&regular_temporary=All&title=&work_location=All',
+];
 
-    const response = await fetch('https://careers.umich.edu/search/feed/advanced?career_interest=All&department=CoE%20Robotics&field_job_modes_of_work_target_id=All&job_id=&keyword=&position=All&regular_temporary=All&title=&work_location=All', {
+// A department feed with more items than this almost certainly means the
+// department filter was ignored and we got university-wide postings.
+const CAREERS_FEED_MAX_ITEMS = 25;
+
+async function fetchCareersFeedItems(url) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(url, {
       signal: controller.signal,
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
       }
     });
 
-    clearTimeout(timeoutId);
-
     if (!response.ok) {
-      console.warn('Careers feed returned non-200 status:', response.status);
-      return [];
+      console.warn(`Careers feed returned non-200 status ${response.status} for ${url}`);
+      return null;
     }
 
     const xmlData = await response.text();
@@ -198,10 +208,24 @@ export async function careersFeedQuery() {
     });
     const parsedData = parser.parse(xmlData);
 
-    let items = parsedData?.rss?.channel?.item;
-    if (!items) return [];
+    if (!parsedData?.rss?.channel) {
+      const contentType = response.headers.get('content-type') || 'unknown';
+      console.warn(`Careers feed response is not RSS (content-type: ${contentType}) for ${url}. First 300 chars:`, xmlData.slice(0, 300));
+      return null;
+    }
+
+    let items = parsedData.rss.channel.item;
+    if (!items) {
+      console.warn(`Careers feed parsed OK but contains zero items for ${url}`);
+      return [];
+    }
     // fast-xml-parser returns a bare object when the feed has a single item
     if (!Array.isArray(items)) items = [items];
+
+    if (items.length > CAREERS_FEED_MAX_ITEMS) {
+      console.warn(`Careers feed returned ${items.length} items for ${url} — department filter likely ignored, discarding`);
+      return null;
+    }
 
     return items.map(item => ({
       // Strip the trailing posting ID, e.g. "Research Administrator (279803)"
@@ -211,10 +235,24 @@ export async function careersFeedQuery() {
     })).filter(item => item.title && item.link);
   } catch (error) {
     if (error.name === 'AbortError') {
-      console.warn('Careers feed request timed out after 5 seconds');
+      console.warn(`Careers feed request timed out after 5 seconds for ${url}`);
     } else {
-      console.error('Error in careersFeedQuery:', error);
+      console.error(`Error fetching careers feed ${url}:`, error);
     }
-    return [];
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+
+export async function careersFeedQuery() {
+  for (const url of CAREERS_FEED_URLS) {
+    const items = await fetchCareersFeedItems(url);
+    if (items && items.length > 0) {
+      console.log(`Careers feed: ${items.length} opening(s) from ${url}`);
+      return items;
+    }
+  }
+  console.warn('Careers feed: no openings found from any feed URL — jobs page will show the empty state');
+  return [];
 }

--- a/src/pages/about/jobs.astro
+++ b/src/pages/about/jobs.astro
@@ -86,7 +86,7 @@ function formatPostedDate(pubDate: string) {
         </ul>
       ) : (
         <Callout type="info">
-          <p>There are no openings posted at the moment. Please check the <a href={careersSearchUrl}>U-M careers site</a> for the latest listings.</p>
+          <p>No openings are showing here right now. For the current list of Robotics Department openings, please visit the <a href={careersSearchUrl}>U-M careers site</a>.</p>
         </Callout>
       )}
 


### PR DESCRIPTION
The jobs page was showing the 'no openings' callout while jobs existed on careers.umich.edu: the build-time feed request succeeds (HTTP 200) but the advanced-search feed filtered by department name parses to zero items, and every failure mode silently collapsed to an empty list.

- Fall back to querying the feed by department taxonomy ID (210308) when the name-filtered feed comes back empty
- Log feed status, content type, item counts, and a body snippet when no items parse, so Netlify build logs show exactly why the list is empty
- Discard responses with implausibly many items (department filter ignored)
- Soften the empty-state message so it points to the careers site instead of asserting there are no openings


Claude-Session: https://claude.ai/code/session_019tsfRb7AK7BD4csWCaQsYt